### PR TITLE
feat: Expose health check endpoint as MCP tool

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -104,6 +104,7 @@
       "mcp__memory__add_observations",
       "mcp__memory__delete_entities",
       "mcp__siemens-acronyms__search_acronyms",
+      "mcp__siemens-acronyms__get_health",
       "mcp__ide__getDiagnostics",
       "mcp__ide__executeCode"
     ],

--- a/MCP_INTEGRATION_GUIDE.md
+++ b/MCP_INTEGRATION_GUIDE.md
@@ -1,0 +1,337 @@
+# MCP Integration Guide: Add AI Assistant Access to Your REST API
+
+## What We Built
+
+We added MCP (Model Context Protocol) support to an existing FastAPI REST API, enabling it to work with AI assistants like Claude Code and VS Code Copilot. This guide shows the exact patterns we used.
+
+## The Architecture Pattern
+
+```
+Your Service (single deployment)
+├── /api/v1/search     → Public REST endpoint (no auth)
+├── /health            → Health check endpoint  
+└── /mcp               → MCP protocol endpoint (API key auth)
+    ├── tools/list     → Discovery: what tools are available
+    └── tools/call     → Execution: run the tools
+```
+
+## Core Implementation Pattern
+
+### 1. The MCP Endpoint Handler
+
+We added one endpoint that handles all MCP protocol methods (`src/main.py:206-307`):
+
+```python
+@app.post("/mcp")
+async def mcp_endpoint(request: Request):
+    """Handle MCP protocol requests."""
+    # Handle body reading if middleware already consumed it
+    if hasattr(request, '_body'):
+        body = json.loads(request._body)
+    else:
+        body = await request.json()
+    
+    method = body.get("method")
+    params = body.get("params", {})
+    request_id = body.get("id")
+    
+    # Protocol handshake
+    if method == "initialize":
+        requested_version = params.get("protocolVersion", "2025-06-18")
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "result": {
+                "protocolVersion": requested_version,  # Echo client's version
+                "capabilities": {"tools": {}, "resources": {}},
+                "serverInfo": {
+                    "name": "siemens-acronyms",
+                    "version": APP_VERSION
+                }
+            },
+            "id": request_id
+        })
+    
+    # Handle notifications (may not have ID)
+    elif method == "initialized":
+        if request_id is not None:
+            return JSONResponse({"jsonrpc": "2.0", "result": {}, "id": request_id})
+        else:
+            return JSONResponse({})
+    
+    # Tool discovery
+    elif method == "tools/list":
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "result": {"tools": [...]},  # Your tools here
+            "id": request_id
+        })
+    
+    # Tool execution
+    elif method == "tools/call":
+        tool_name = params.get("name")
+        # Route to appropriate tool handler
+```
+
+### 2. Authentication Pattern: Protected MCP, Public REST
+
+We protect only the MCP endpoint while keeping REST public (`src/main.py:172-202`):
+
+```python
+@app.middleware("http")
+async def mcp_auth_middleware(request: Request, call_next):
+    """Add authentication to MCP endpoints only."""
+    if request.url.path.startswith("/mcp"):
+        # Special case: get_health tool bypasses auth
+        try:
+            body = await request.body()
+            request._body = body  # Store for later use
+            body_json = json.loads(body) if body else {}
+            method = body_json.get("method")
+            
+            if method == "tools/call":
+                tool_name = body_json.get("params", {}).get("name")
+                if tool_name == "get_health":
+                    # Skip auth for public tools
+                    response = await call_next(request)
+                    return response
+        except Exception:
+            pass
+        
+        # Check API key for other requests
+        api_key = request.headers.get("X-API-Key")
+        allowed_keys = os.getenv("GLOSSARY_API_KEYS", "").split(",")
+        allowed_keys = [key.strip() for key in allowed_keys if key.strip()]
+        
+        if api_key not in allowed_keys:
+            return JSONResponse(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                content={"error": "Invalid or missing API key"}
+            )
+    
+    return await call_next(request)
+```
+
+### 3. Tool Definition Pattern
+
+We define tools with FastMCP decorators and expose them via tools/list (`src/main.py:72-101`):
+
+```python
+# Tool with parameters (requires auth)
+@mcp.tool()
+async def search_acronyms(query: str) -> str:
+    """Search for Siemens acronyms and terminology."""
+    results = await acronyms_service.search(query)
+    return json.dumps({"results": results, "query": query, "count": len(results)})
+
+# Tool without parameters (public access)
+@mcp.tool()
+async def get_health() -> str:
+    """Get server health status including uptime and hostname."""
+    health_data = {
+        "status": "healthy",
+        "hostname": socket.gethostname(),
+        "uptime": time.time() - APP_START_TIME,
+        "version": APP_VERSION
+    }
+    return json.dumps(health_data)
+```
+
+### 4. Tool Discovery Response
+
+In tools/list handler (`src/main.py:227-257`):
+
+```python
+"tools": [
+    {
+        "name": "search_acronyms",
+        "description": "Search for Siemens acronyms and terminology",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "The term or acronym to search for"}
+            },
+            "required": ["query"]
+        }
+    },
+    {
+        "name": "get_health",
+        "description": "Get server health status including uptime and hostname",
+        "inputSchema": {
+            "type": "object",
+            "properties": {},
+            "required": []  # No parameters required
+        }
+    }
+]
+```
+
+### 5. Tool Execution Pattern
+
+In tools/call handler (`src/main.py:259-299`):
+
+```python
+elif method == "tools/call":
+    tool_name = params.get("name")
+    
+    if tool_name == "search_acronyms":
+        query = params.get("arguments", {}).get("query", "")
+        results = await acronyms_service.search(query)
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps({"results": results, "query": query, "count": len(results)})
+                }]
+            },
+            "id": request_id
+        })
+    
+    elif tool_name == "get_health":
+        health_data = {
+            "status": "healthy",
+            "hostname": socket.gethostname(),
+            "uptime": time.time() - APP_START_TIME,
+            "version": APP_VERSION
+        }
+        return JSONResponse({
+            "jsonrpc": "2.0",
+            "result": {
+                "content": [{
+                    "type": "text",
+                    "text": json.dumps(health_data)
+                }]
+            },
+            "id": request_id
+        })
+```
+
+## Key Implementation Lessons
+
+### 1. Protocol Version Negotiation
+**Issue**: Clients send different protocol versions.
+**Solution**: Always echo back the client's requested version, don't hardcode.
+
+### 2. Request Body Consumption
+**Issue**: Middleware reading request body prevents endpoint from reading it.
+**Solution**: Store body in request object after reading in middleware.
+
+### 3. Mixed Authentication
+**Issue**: Some tools should be public, others protected.
+**Solution**: Check tool name in middleware and selectively bypass auth.
+
+### 4. Notification Handling
+**Issue**: MCP sends notifications that may not have request IDs.
+**Solution**: Check if ID exists before including in response.
+
+## Testing Patterns We Used
+
+### Test Structure (`tests/test_acronyms_server.py`)
+
+```python
+class TestMCPHealthTool:
+    """Tests for MCP health check tool"""
+    
+    def test_mcp_health_without_auth(self):
+        """Test that get_health tool works without API key"""
+        client = TestClient(app)
+        response = client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "get_health", "arguments": {}},
+                "id": 1
+            }
+        )
+        assert response.status_code == status.HTTP_200_OK
+        
+    @patch.dict(os.environ, {"GLOSSARY_API_KEYS": "sk-test-123"})
+    def test_mcp_health_tool_in_list(self):
+        """Test that get_health tool appears in tools/list"""
+        # Test with authentication for protected endpoints
+```
+
+### Test Coverage Areas
+- Tool discovery (tools appear in list)
+- Authentication bypass for public tools
+- Authentication required for protected tools
+- Response format validation
+- Uptime tracking accuracy
+- Handling of extra parameters
+
+## Client Configuration
+
+### Claude Code CLI
+```bash
+# Add the server
+claude mcp add siemens-acronyms http://localhost:8000/mcp \
+  --header "X-API-Key: sk-team-A"
+
+# Test it works
+claude -p "Using siemens-acronyms MCP, check the server health"
+```
+
+### VS Code GitHub Copilot
+Create `.vscode/mcp.json`:
+```json
+{
+  "servers": {
+    "siemens-acronyms": {
+      "type": "http",
+      "url": "http://localhost:8000/mcp",
+      "headers": {
+        "X-API-Key": "sk-team-A"
+      }
+    }
+  }
+}
+```
+
+### Claude Code Permissions
+Add to `.claude/settings.json`:
+```json
+"permissions": {
+  "allow": [
+    "mcp__siemens-acronyms__search_acronyms",
+    "mcp__siemens-acronyms__get_health"
+  ]
+}
+```
+
+## Environment Variables
+
+```env
+# API keys for MCP authentication (comma-separated)
+GLOSSARY_API_KEYS=sk-team-A,sk-team-B,sk-team-C
+
+# Optional configuration
+LOG_LEVEL=INFO
+GLOSSARY_FILE_PATH=siemens_acronyms.json
+```
+
+## What This Pattern Gives You
+
+1. **Single deployment**: REST and MCP in one service
+2. **Backward compatibility**: Existing REST clients continue working
+3. **Selective authentication**: Mix public and protected tools
+4. **Hot reload**: Data changes apply to both protocols
+5. **AI assistant access**: Works with Claude, Copilot, and other MCP clients
+
+## Files to Reference
+
+- `src/main.py` - Complete implementation (lines 172-307 for MCP)
+- `tests/test_acronyms_server.py` - Test patterns (lines 340-505)
+- `.env.example` - Environment variable template
+- `.vscode/mcp.json` - VS Code configuration
+- `.claude/settings.json` - Claude permissions
+
+## Tested With
+
+✅ Claude Code CLI  
+✅ VS Code GitHub Copilot  
+✅ 37 passing tests  
+✅ Both public and protected tools  
+✅ Fuzzy search functionality  
+
+This implementation adds ~130 lines to expose your REST API to AI assistants via MCP, maintaining full backward compatibility.

--- a/README.md
+++ b/README.md
@@ -123,7 +123,19 @@ curl "http://localhost:8000/api/v1/search?q=Sim"
 
 **Endpoint:** `POST /mcp`
 
-Requires `X-API-Key` header with valid API key from `GLOSSARY_API_KEYS`.
+Requires `X-API-Key` header with valid API key from `GLOSSARY_API_KEYS` (except for the `get_health` tool).
+
+**Available MCP Tools:**
+
+1. **`search_acronyms`** - Search for Siemens acronyms and terminology
+   - Parameters: `query` (string, required)
+   - Returns: Matching terms with fuzzy search support
+   - Authentication: Required
+
+2. **`get_health`** - Get server health status
+   - Parameters: None
+   - Returns: Server status, hostname, uptime, and version
+   - Authentication: Not required (public tool)
 
 ```bash
 # List available tools
@@ -132,7 +144,7 @@ curl -X POST http://localhost:8000/mcp \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc": "2.0", "method": "tools/list", "id": 1}'
 
-# Search using MCP protocol
+# Search using MCP protocol (requires authentication)
 curl -X POST http://localhost:8000/mcp \
   -H "X-API-Key: sk-team-A" \
   -H "Content-Type: application/json" \
@@ -144,6 +156,19 @@ curl -X POST http://localhost:8000/mcp \
       "arguments": {"query": "DISW"}
     },
     "id": 2
+  }'
+
+# Get health status via MCP (no authentication required)
+curl -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "method": "tools/call",
+    "params": {
+      "name": "get_health",
+      "arguments": {}
+    },
+    "id": 3
   }'
 ```
 

--- a/analysis/4/DESIGN.md
+++ b/analysis/4/DESIGN.md
@@ -1,0 +1,150 @@
+# Expose Health Check as MCP Tool for Service Discovery and Monitoring
+
+## Problem / Metric
+Currently, the health check endpoint (`/health`) is only accessible via REST API, not through the MCP protocol. This means AI assistants and MCP clients cannot programmatically check the server's status, hostname, or uptime without making direct HTTP calls outside the MCP protocol. This limits service discovery and monitoring capabilities for MCP-native clients.
+
+**Metric**: Enable 100% of MCP clients to query server health status through the standard MCP tools interface without requiring additional HTTP client configuration.
+
+## Goal
+Expose the existing health check functionality as an MCP tool that can be discovered via `tools/list` and invoked via `tools/call`, providing the same information as the REST endpoint (status, hostname, uptime, version) but through the MCP protocol. The tool should be public (no authentication required) for both developers and LLMs to monitor service health.
+
+## Scope (M/S/W)
+- [M] Create new MCP tool `get_health` that returns health status
+- [M] Tool returns: status, hostname, uptime, version (same as REST endpoint)
+- [M] No authentication required for this tool (public access)
+- [M] Tool appears in `tools/list` discovery
+- [M] Tool callable via `tools/call` with no parameters
+- [S] Add unit tests for the new MCP tool
+- [S] Update documentation to reflect new tool availability
+- [W] Remove or deprecate existing REST health endpoint
+- [W] Add additional monitoring metrics beyond current fields
+- [W] Implement health history or trend tracking
+
+## Acceptance Criteria
+| # | Given | When | Then |
+|---|-------|------|------|
+| 1 | MCP server is running | Client calls `tools/list` | Response includes `get_health` tool with proper schema |
+| 2 | MCP client without API key | Calls `get_health` tool via MCP | Returns health data with 200 status (no auth required) |
+| 3 | MCP client with valid API key | Calls `get_health` tool | Returns same health data (auth not checked for this tool) |
+| 4 | Server has been running 5 minutes | `get_health` tool is called | Returns uptime ≈ 300 seconds |
+| 5 | Server is on host "prod-server-01" | `get_health` tool is called | Returns hostname: "prod-server-01" |
+| 6 | MCP tool call with extra params | `get_health` called with unexpected args | Ignores extra params, returns health data |
+| 7 | Claude Code or VS Code | Uses MCP to check server health | Successfully receives health status via MCP protocol |
+
+## Technical Design
+
+### Architecture Changes
+```
+Current State:
+- REST: GET /health → HealthResponse
+- MCP: Only search_acronyms tool available
+
+Proposed State:
+- REST: GET /health → HealthResponse (unchanged)
+- MCP: Two tools available:
+  1. search_acronyms (existing)
+  2. get_health (new, public)
+```
+
+### Implementation Approach
+1. **Add new MCP tool decorator** in `main.py`:
+   ```python
+   @mcp.tool()
+   async def get_health() -> str:
+       """Get server health status including uptime and hostname."""
+       health_data = {
+           "status": "healthy",
+           "hostname": socket.gethostname(),
+           "uptime": time.time() - APP_START_TIME,
+           "version": APP_VERSION
+       }
+       return json.dumps(health_data)
+   ```
+
+2. **Update tools/list response** to include the new tool with no required parameters
+
+3. **Modify authentication middleware** to explicitly allow `get_health` tool calls without API key validation:
+   ```python
+   # In tools/call handler
+   if tool_name == "get_health":
+       # No auth check - public tool
+       result = await get_health()
+   elif tool_name == "search_acronyms":
+       # Existing auth flow for protected tools
+       ...
+   ```
+
+### Tool Schema
+```json
+{
+  "name": "get_health",
+  "description": "Get server health status including uptime and hostname",
+  "inputSchema": {
+    "type": "object",
+    "properties": {},
+    "required": []
+  }
+}
+```
+
+## Implementation Steps
+1. **Add MCP tool function** (`src/main.py:72-85`)
+   - Add `@mcp.tool()` decorated `get_health()` function after `search_acronyms`
+   - Return JSON string with health data matching REST endpoint format
+
+2. **Update tools/list handler** (`src/main.py:210-231`)
+   - Add `get_health` tool definition to the tools array
+   - Include empty inputSchema (no parameters required)
+
+3. **Update tools/call handler** (`src/main.py:233-251`)
+   - Add conditional branch for `tool_name == "get_health"`
+   - Call `get_health()` function without auth check
+   - Return result in standard MCP format
+
+4. **Bypass authentication for health tool** (`src/main.py:156-168`)
+   - Modify middleware to skip auth for `get_health` tool calls
+   - Or handle within tools/call to avoid auth before tool execution
+
+5. **Add tests** (`tests/test_acronyms_server.py`)
+   - Test `get_health` appears in tools/list
+   - Test calling without API key succeeds
+   - Test response contains all required fields
+   - Test uptime increases between calls
+
+6. **Update documentation**
+   - Add `get_health` tool to README.md MCP tools section
+   - Update INTEGRATION_GUIDE.md with health check example
+
+## Testing Strategy
+1. **Unit Tests**:
+   - `test_mcp_health_tool_in_list()` - Verify tool appears in discovery
+   - `test_mcp_health_without_auth()` - Confirm no API key required
+   - `test_mcp_health_response_fields()` - Validate all fields present
+   - `test_mcp_health_uptime_increases()` - Check uptime calculation
+
+2. **Integration Tests**:
+   - Test with Claude Code CLI: `claude -p "Using siemens-acronyms MCP, check the server health"`
+   - Test with VS Code MCP client
+   - Verify tool works alongside existing `search_acronyms` tool
+
+3. **Manual Testing**:
+   ```bash
+   # Direct MCP protocol test
+   curl -X POST http://localhost:8000/mcp \
+     -H "Content-Type: application/json" \
+     -d '{
+       "jsonrpc": "2.0",
+       "method": "tools/call",
+       "params": {"name": "get_health", "arguments": {}},
+       "id": 1
+     }'
+   ```
+
+## Risks & Considerations
+- **Security**: Making health endpoint public via MCP could expose server details (hostname). This is acceptable for internal services but should be documented.
+- **Backwards Compatibility**: Existing REST endpoint remains unchanged, no breaking changes.
+- **Performance**: Health check is lightweight, no performance concerns.
+- **Caching**: Consider if health data should be cached (probably not - want real-time data).
+- **Error Handling**: If server is unhealthy, should tool return error or unhealthy status? (Return unhealthy status for monitoring tools to parse).
+- **Tool Naming**: Using `get_health` to match REST endpoint pattern, could use `check_health` or `health_status` instead.
+- **Authentication Bypass**: Need to ensure ONLY the health tool bypasses auth, not all tools.


### PR DESCRIPTION
## Summary
- Implemented `get_health` MCP tool for service monitoring without authentication
- Created comprehensive MCP Integration Guide for developers
- Added full test coverage with 6 new tests

## Implementation Details

### New MCP Tool: `get_health`
- Returns server status, hostname, uptime, and version
- No authentication required (public access)
- Bypasses API key middleware for this specific tool
- Works with both authenticated and unauthenticated clients

### MCP Integration Guide
Created a comprehensive guide documenting:
- Patterns for adding MCP support to REST APIs
- Authentication strategies for mixed public/private tools
- Request body handling in middleware
- Real code examples with line references
- Testing patterns from our implementation

## Changes
- `src/main.py`: Added get_health tool and authentication bypass
- `tests/test_acronyms_server.py`: Added TestMCPHealthTool class with 6 tests
- `README.md`: Documented new MCP tool with usage examples
- `MCP_INTEGRATION_GUIDE.md`: Complete guide for developers (new file)
- `.claude/settings.json`: Added permission for get_health tool
- `analysis/4/DESIGN.md`: Design document for this feature

## Testing
- ✅ All 37 tests passing
- ✅ Tested with Claude Code CLI
- ✅ Tested with VS Code GitHub Copilot
- ✅ Verified authentication bypass works correctly
- ✅ Confirmed uptime tracking functions properly

## Acceptance Criteria Met
- [x] MCP clients can discover `get_health` tool via `tools/list`
- [x] Tool returns: status, hostname, uptime, version
- [x] No authentication required
- [x] Tool works without any input parameters
- [x] Both authenticated and unauthenticated clients can access the tool
- [x] Tool response format matches MCP protocol standards

Closes #4